### PR TITLE
check challenge data in Present.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+jobs:
+  release:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5.3.0
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/thg-ice/cert-manager-webhook-ns1:${{ github.ref_name }}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func (c *ns1DNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 		}
 		ok, checkErr := c.checkChallengeData(zone, record.Domain, ch.Key)
 		if checkErr != nil {
-			return fmt.Errorf("checkRecordExists: %w", checkErr)
+			return fmt.Errorf("checkChallengeData: %w", checkErr)
 		}
 		if !ok {
 			return txtRecordExists

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -24,6 +25,7 @@ import (
 )
 
 var groupName = os.Getenv("GROUP_NAME")
+var txtRecordExists = errors.New("TXT record exists with different challenge data")
 
 func main() {
 	if groupName == "" {
@@ -98,12 +100,35 @@ func (c *ns1DNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 
 	_, err = c.ns1Client.Records.Create(record)
 	if err != nil {
-	  if err != ns1API.ErrRecordExists {
-			return err
+		if err != ns1API.ErrRecordExists {
+			return fmt.Errorf("error creating record: %w", err)
+		}
+		ok, checkErr := c.checkChallengeData(zone, record.Domain, ch.Key)
+		if checkErr != nil {
+			return fmt.Errorf("checkRecordExists: %w", checkErr)
+		}
+		if !ok {
+			return txtRecordExists
 		}
 	}
 
 	return nil
+}
+
+// checkChallengeData checks if a TXT record exists with the given content.
+func (c *ns1DNSProviderSolver) checkChallengeData(zone, fqdn, content string) (bool, error) {
+	record, _, err := c.ns1Client.Records.Get(zone, fqdn, "TXT")
+	if err != nil {
+		return false, err
+	}
+	for _, ans := range record.Answers {
+		for _, data := range ans.Rdata {
+			if data == content {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // CleanUp should delete the relevant TXT record from the DNS provider console.
@@ -233,7 +258,7 @@ func (c *ns1DNSProviderSolver) parseChallenge(ch *v1alpha1.ChallengeRequest) (
 	}
 	zone = util.UnFqdn(zone)
 
-	if idx := strings.Index(ch.ResolvedFQDN, "." + ch.ResolvedZone); idx != -1 {
+	if idx := strings.Index(ch.ResolvedFQDN, "."+ch.ResolvedZone); idx != -1 {
 		domain = ch.ResolvedFQDN[:idx]
 	} else {
 		domain = util.UnFqdn(ch.ResolvedFQDN)


### PR DESCRIPTION
this is to allow concurrent challenges for the same domain to work. we fail early to avoid having to coordinate:
 * adding/removing answers from,
 * and deleting the record.